### PR TITLE
refact: win, dll load, only sys&user dirs

### DIFF
--- a/AMF_v1.4.35/amf/public/common/Windows/ThreadWindows.cpp
+++ b/AMF_v1.4.35/amf/public/common/Windows/ThreadWindows.cpp
@@ -402,10 +402,7 @@ amf_handle AMF_CDECL_CALL amf_load_library(const wchar_t* filename)
 #if defined(METRO_APP)
     return LoadPackagedLibrary(filename, 0);
 #else
-	return ::LoadLibraryExW(filename, NULL, LOAD_LIBRARY_SEARCH_USER_DIRS |
-		LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
-		LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
-		LOAD_LIBRARY_SEARCH_SYSTEM32);
+	return ::LoadLibraryExW(filename, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS);
 #endif
 }
 //----------------------------------------------------------------------------------------

--- a/MediaSDK_22.5.4/api/mfx_dispatch/windows/src/mfx_dxva2_device.cpp
+++ b/MediaSDK_22.5.4/api/mfx_dispatch/windows/src/mfx_dxva2_device.cpp
@@ -106,7 +106,7 @@ void DXDevice::LoadDLLModule(const wchar_t *pModuleName)
 #endif // !defined(MEDIASDK_UWP_DISPATCHER)
 
     // load specified library
-    m_hModule = LoadLibraryExW(pModuleName, NULL, 0);
+    m_hModule = LoadLibraryExW(pModuleName, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS);
 
 #if !defined(MEDIASDK_UWP_DISPATCHER)
     // set the previous error mode


### PR DESCRIPTION
Prevent the DLLs loading from the application directory.